### PR TITLE
Enhance authentication documentation and introduce custom route paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,12 +135,19 @@ The SDK is built around a provider-based architecture with MCP integration and P
    - `createNextAuthHandler(config, options)`: Route-handler-style function used by Proxy/Route Handlers
    - `authMiddleware(configOrOptions, options)`: Zero-config authentication for **Next.js 16 Proxy** (formerly Middleware)
      - Handles all flows under a base path (default `/auth`, recommended `/api/auth`)
-     - Endpoints:
+     - Default Endpoints:
        - `GET {basePath}/session` → session JSON
        - `POST {basePath}/signout` → clears cookie
        - `GET {basePath}/signin/{provider}` → start OAuth
        - `GET {basePath}/callback/{provider}` → finalize OAuth, set cookie, redirect
        - `POST {basePath}/signin/email` → send magic link (Node runtime recommended)
+     - **Custom Route Paths**: Configure custom authentication routes via `options.routes`:
+       - `session`: Custom session endpoint (default: `{basePath}/session`)
+       - `signOut`: Custom logout endpoint (default: `{basePath}/signout`)
+       - `signIn`: Custom sign-in pattern with `{provider}` placeholder (default: `{basePath}/signin/{provider}`)
+       - `callback`: Custom callback pattern with `{provider}` placeholder (default: `{basePath}/callback/{provider}`)
+       - Example: `routes: { session: "/api/user/me", signOut: "/api/auth/logout", signIn: "/login/{provider}", callback: "/auth/verify/{provider}" }`
+       - See [Custom Route Paths Guide](content/docs/03-guides/06-custom-route-paths.mdx) for details
    - Zero-config via env: `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`
    - Import: `import { authMiddleware } from '@warpy-auth-sdk/core/next'`
 

--- a/content/docs/03-guides/06-custom-route-paths.mdx
+++ b/content/docs/03-guides/06-custom-route-paths.mdx
@@ -1,0 +1,345 @@
+import { DocsLayout } from '@/components/docs/docs-layout';
+import { CodeBlock } from '@/components/docs/code-block';
+import { Callout } from '@/components/docs/callout';
+import { Example } from '@/components/docs/example';
+
+export const metadata = {
+  title: 'Custom Route Paths - @warpy-auth-sdk/core',
+  description: 'Configure custom authentication route paths for your Next.js application.',
+};
+
+export default function CustomRoutePathsGuide() {
+  return (
+    <DocsLayout
+      title="Custom Route Paths"
+      description="Configure custom authentication route paths for your Next.js application."
+      previousPage={{ title: 'CAPTCHA Integration', href: '/docs/guides/captcha-integration' }}
+      nextPage={{ title: 'MCP Introduction', href: '/docs/mcp/introduction' }}
+    >
+      <div>
+        <h2>Overview</h2>
+        <p>
+          By default, @warpy-auth-sdk/core uses a standardized route structure for authentication
+          endpoints (e.g., <code>/api/auth/signin/google</code>, <code>/api/auth/callback/google</code>).
+          However, you can customize these paths to match your application's routing conventions.
+        </p>
+
+        <h2>Default Route Structure</h2>
+        <p>
+          The default routes follow this pattern:
+        </p>
+
+        <CodeBlock language="typescript">
+{`// Default routes with basePath: "/api/auth"
+GET  /api/auth/session              // Get current session
+POST /api/auth/signout              // Sign out user
+GET  /api/auth/signin/{provider}    // Initiate sign-in (e.g., /api/auth/signin/google)
+POST /api/auth/signin/email         // Send magic link email
+GET  /api/auth/callback/{provider}  // OAuth callback (e.g., /api/auth/callback/google)`}
+        </CodeBlock>
+
+        <h2>Custom Route Configuration</h2>
+        <p>
+          You can override these routes using the <code>routes</code> option in <code>NextAuthHandlerOptions</code>:
+        </p>
+
+        <Example
+          title="Custom Route Paths"
+          description="Configure custom authentication routes"
+          code={`import { authMiddleware } from "@warpy-auth-sdk/core/next";
+import { google } from "@warpy-auth-sdk/core";
+
+const handler = authMiddleware(
+  {
+    secret: process.env.AUTH_SECRET!,
+    provider: google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      redirectUri: process.env.GOOGLE_REDIRECT_URI!,
+    }),
+  },
+  {
+    basePath: "/api/auth",
+
+    // Custom route paths
+    routes: {
+      session: "/api/user/session",           // Custom session endpoint
+      signOut: "/api/user/logout",            // Custom logout endpoint
+      signIn: "/login/{provider}",            // Custom sign-in pattern
+      callback: "/auth/verify/{provider}",    // Custom callback pattern
+    },
+
+    successRedirect: "/dashboard",
+    errorRedirect: "/login",
+  }
+);`}
+        />
+
+        <Callout type="info" title="Provider Placeholder">
+          The <code>{'{provider}'}</code> placeholder in <code>signIn</code> and <code>callback</code>
+          routes will be replaced with the actual provider name (e.g., <code>google</code>, <code>github</code>,
+          <code>email</code>, <code>twofa</code>).
+        </Callout>
+
+        <h2>Complete Example</h2>
+        <p>
+          Here's a complete example with custom routes in a Next.js 16 Proxy:
+        </p>
+
+        <Example
+          title="proxy.ts"
+          description="Next.js Proxy with custom authentication routes"
+          code={`import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { authMiddleware } from "@warpy-auth-sdk/core/next";
+import { google, github } from "@warpy-auth-sdk/core";
+
+const handler = authMiddleware(
+  {
+    secret: process.env.AUTH_SECRET!,
+    provider: google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      redirectUri: "http://localhost:3000/auth/verify/google",
+    }),
+    callbacks: {
+      async user(u) {
+        return {
+          id: u.id || u.email,
+          email: u.email,
+          name: u.name,
+          picture: u.picture,
+        };
+      },
+    },
+  },
+  {
+    basePath: "/api/auth", // Not used when routes are fully customized
+
+    routes: {
+      session: "/api/user/me",
+      signOut: "/api/auth/logout",
+      signIn: "/login/{provider}",
+      callback: "/auth/verify/{provider}",
+    },
+
+    successRedirect: "/dashboard",
+    errorRedirect: "/",
+  }
+);
+
+export function proxy(request: NextRequest) {
+  const p = request.nextUrl.pathname;
+
+  // Match all custom routes
+  if (
+    p.startsWith("/login/") ||
+    p.startsWith("/auth/verify/") ||
+    p === "/api/user/me" ||
+    p === "/api/auth/logout"
+  ) {
+    return handler(request);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/(api|trpc)(.*)",
+  ],
+};`}
+        />
+
+        <h2>Client-Side Usage</h2>
+        <p>
+          When using custom routes, update your client-side code to use the new paths:
+        </p>
+
+        <Example
+          title="Custom Routes in React"
+          description="Using custom authentication routes in your components"
+          code={`'use client';
+
+import { useAuth } from "@warpy-auth-sdk/core/hooks";
+import { useState } from "react";
+
+export default function LoginPage() {
+  const { session, loading } = useAuth();
+  const [email, setEmail] = useState('');
+
+  const handleEmailSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // Use custom email sign-in endpoint
+    const response = await fetch('/login/email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+
+    // Handle response...
+  };
+
+  const handleSignOut = async () => {
+    // Use custom logout endpoint
+    await fetch('/api/auth/logout', { method: 'POST' });
+    window.location.href = '/';
+  };
+
+  return (
+    <div>
+      {session ? (
+        <div>
+          <p>Welcome, {session.user.name}</p>
+          <button onClick={handleSignOut}>Sign Out</button>
+        </div>
+      ) : (
+        <div>
+          {/* Use custom OAuth sign-in path */}
+          <a href="/login/google">
+            Sign in with Google
+          </a>
+
+          <a href="/login/github">
+            Sign in with GitHub
+          </a>
+
+          {/* Email sign-in form */}
+          <form onSubmit={handleEmailSubmit}>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <button type="submit">Send Magic Link</button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}`}
+        />
+
+        <h2>useAuth Hook Configuration</h2>
+        <p>
+          If you customize the <code>session</code> endpoint, you need to update the <code>AuthProvider</code>
+          configuration:
+        </p>
+
+        <Example
+          title="Custom Session Endpoint"
+          description="Configure AuthProvider with custom session endpoint"
+          code={`import { AuthProvider } from "@warpy-auth-sdk/core/hooks";
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <AuthProvider sessionEndpoint="/api/user/me">
+          {children}
+        </AuthProvider>
+      </body>
+    </html>
+  );
+}`}
+        />
+
+        <h2>Common Patterns</h2>
+
+        <h3>RESTful API Style</h3>
+        <CodeBlock language="typescript">
+{`routes: {
+  session: "/api/user/session",
+  signOut: "/api/user/session",     // DELETE method on same endpoint
+  signIn: "/api/auth/{provider}",
+  callback: "/api/auth/{provider}/callback",
+}`}
+        </CodeBlock>
+
+        <h3>Simplified Paths</h3>
+        <CodeBlock language="typescript">
+{`routes: {
+  session: "/session",
+  signOut: "/logout",
+  signIn: "/signin/{provider}",
+  callback: "/callback/{provider}",
+}`}
+        </CodeBlock>
+
+        <h3>Clerk-like Convention</h3>
+        <CodeBlock language="typescript">
+{`routes: {
+  session: "/api/auth/session",
+  signOut: "/api/auth/sign-out",
+  signIn: "/api/auth/sign-in/{provider}",
+  callback: "/api/auth/callback/{provider}",
+}`}
+        </CodeBlock>
+
+        <h2>Important Considerations</h2>
+
+        <Callout type="warning" title="Update OAuth Redirect URIs">
+          When customizing the <code>callback</code> route, make sure to update your OAuth provider
+          redirect URIs to match the new pattern. For example, if you set
+          <code>callback: "/auth/verify/{'{provider}'}"</code>, your Google redirect URI should be
+          <code>http://yourdomain.com/auth/verify/google</code>.
+        </Callout>
+
+        <Callout type="info" title="Proxy Matcher">
+          When using custom routes outside of <code>basePath</code>, ensure your Next.js Proxy
+          <code>matcher</code> configuration or manual path checks cover the new route patterns.
+        </Callout>
+
+        <h3>Email Provider Callback</h3>
+        <p>
+          The email magic link provider automatically uses your custom callback route. The callback
+          URL will be built using the <code>callback</code> pattern with <code>email</code> as the provider:
+        </p>
+
+        <CodeBlock language="typescript">
+{`// With routes.callback = "/auth/verify/{provider}"
+// Email magic link will redirect to: /auth/verify/email?token=...&email=...`}
+        </CodeBlock>
+
+        <h3>Two-Factor Authentication</h3>
+        <p>
+          Two-factor authentication uses the <code>signIn</code> route with <code>twofa</code> as the provider:
+        </p>
+
+        <CodeBlock language="typescript">
+{`// With routes.signIn = "/login/{provider}"
+// 2FA endpoint: GET /login/twofa?identifier=...&code=...`}
+        </CodeBlock>
+
+        <h2>Troubleshooting</h2>
+
+        <h3>404 Errors</h3>
+        <p>
+          If you're getting 404 errors with custom routes:
+        </p>
+        <ol>
+          <li>Verify your Proxy <code>matcher</code> includes the custom paths</li>
+          <li>Check that the handler is being called for the custom routes in your <code>proxy()</code> function</li>
+          <li>Ensure the <code>{'{provider}'}</code> placeholder is used correctly in patterns</li>
+        </ol>
+
+        <h3>OAuth Redirect Mismatch</h3>
+        <p>
+          If OAuth providers show redirect URI mismatch errors:
+        </p>
+        <ol>
+          <li>Update the <code>redirectUri</code> in your provider configuration</li>
+          <li>Add the new callback URL to your OAuth app's allowed redirect URIs</li>
+          <li>Restart your development server</li>
+        </ol>
+
+        <Callout type="success" title="Flexibility">
+          Custom route paths allow you to integrate @warpy-auth-sdk/core seamlessly with any
+          routing convention or API design pattern in your application.
+        </Callout>
+      </div>
+    </DocsLayout>
+  );
+}

--- a/examples/nextjs-captcha-example/README-CUSTOM-ROUTES.md
+++ b/examples/nextjs-captcha-example/README-CUSTOM-ROUTES.md
@@ -1,0 +1,170 @@
+# Custom Route Paths Example
+
+This example demonstrates how to use custom authentication route paths with @warpy-auth-sdk/core.
+
+## Default Routes
+
+By default, the SDK uses these routes:
+
+```
+GET  /api/auth/session              # Get current session
+POST /api/auth/signout              # Sign out
+GET  /api/auth/signin/{provider}    # Start OAuth sign-in
+POST /api/auth/signin/email         # Send magic link
+GET  /api/auth/callback/{provider}  # OAuth callback
+```
+
+## Custom Routes Configuration
+
+You can customize these paths using the `routes` option:
+
+### Example: Custom Paths
+
+```typescript
+// proxy.ts
+import { authMiddleware } from "@warpy-auth-sdk/core/next";
+import { google } from "@warpy-auth-sdk/core";
+
+const handler = authMiddleware(
+  {
+    secret: process.env.AUTH_SECRET!,
+    provider: google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      // IMPORTANT: Update redirect URI to match custom callback path
+      redirectUri: "http://localhost:3000/auth/verify/google",
+    }),
+  },
+  {
+    basePath: "/api/auth", // Only used as fallback
+
+    // Custom route paths
+    routes: {
+      session: "/api/user/me",
+      signOut: "/api/auth/logout",
+      signIn: "/login/{provider}",
+      callback: "/auth/verify/{provider}",
+    },
+
+    successRedirect: "/dashboard",
+    errorRedirect: "/signin",
+  }
+);
+
+export function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  // Match custom routes
+  if (
+    pathname.startsWith("/login/") ||
+    pathname.startsWith("/auth/verify/") ||
+    pathname === "/api/user/me" ||
+    pathname === "/api/auth/logout"
+  ) {
+    return handler(request);
+  }
+
+  return NextResponse.next();
+}
+```
+
+## Updated Client Code
+
+### Custom Sign-in Links
+
+```tsx
+// app/signin/page.tsx
+export default function SignInPage() {
+  return (
+    <div>
+      {/* Use custom sign-in path */}
+      <a href="/login/google">Sign in with Google</a>
+      <a href="/login/github">Sign in with GitHub</a>
+    </div>
+  );
+}
+```
+
+### Custom Session Endpoint
+
+```tsx
+// app/layout.tsx
+import { AuthProvider } from "@warpy-auth-sdk/core/hooks";
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        {/* Configure custom session endpoint */}
+        <AuthProvider sessionEndpoint="/api/user/me">
+          {children}
+        </AuthProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+### Custom Sign-out
+
+```tsx
+// components/SignOutButton.tsx
+export function SignOutButton() {
+  const handleSignOut = async () => {
+    // Use custom logout endpoint
+    await fetch('/api/auth/logout', { method: 'POST' });
+    window.location.href = '/';
+  };
+
+  return <button onClick={handleSignOut}>Sign Out</button>;
+}
+```
+
+## Common Route Patterns
+
+### RESTful API Style
+
+```typescript
+routes: {
+  session: "/api/user/session",
+  signOut: "/api/user/session", // DELETE on same endpoint
+  signIn: "/api/auth/{provider}",
+  callback: "/api/auth/{provider}/callback",
+}
+```
+
+### Clerk-like Convention
+
+```typescript
+routes: {
+  session: "/api/auth/session",
+  signOut: "/api/auth/sign-out",
+  signIn: "/api/auth/sign-in/{provider}",
+  callback: "/api/auth/callback/{provider}",
+}
+```
+
+### Simplified Paths
+
+```typescript
+routes: {
+  session: "/session",
+  signOut: "/logout",
+  signIn: "/signin/{provider}",
+  callback: "/callback/{provider}",
+}
+```
+
+## Important Notes
+
+1. **OAuth Redirect URIs**: Update your OAuth provider redirect URIs to match custom callback paths
+2. **Proxy Matcher**: Ensure Next.js proxy matcher includes custom route patterns
+3. **{provider} Placeholder**: Will be replaced with actual provider name (google, github, email, twofa)
+4. **AuthProvider**: Update `sessionEndpoint` prop if you customize the session route
+
+## Benefits
+
+- Match your existing API conventions
+- Cleaner, more semantic URLs
+- Better integration with existing routing
+- Flexibility for different environments (staging, production)

--- a/examples/nextjs-captcha-example/proxy.ts
+++ b/examples/nextjs-captcha-example/proxy.ts
@@ -44,6 +44,14 @@ const handler = authMiddleware(
     basePath: "/api/auth",
     successRedirect: "/dashboard",
     errorRedirect: "/signin",
+
+    // Optional: Customize authentication route paths
+    // routes: {
+    //   session: "/api/user/session",
+    //   signOut: "/api/user/logout",
+    //   signIn: "/login/{provider}",
+    //   callback: "/auth/verify/{provider}",
+    // },
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warpy-auth-sdk/core",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "auth-sdk",
   "main": "./dist/index.js",
   "type": "module",

--- a/src/next/handler.ts
+++ b/src/next/handler.ts
@@ -29,6 +29,31 @@ export interface NextAuthHandlerOptions {
   basePath?: string; // e.g., '/auth' or '/api/auth'
   successRedirect?: string; // where to redirect after successful callback
   errorRedirect?: string; // where to redirect on error
+  routes?: {
+    session?: string; // default: '{basePath}/session'
+    signOut?: string; // default: '{basePath}/signout'
+    signIn?: string; // default: '{basePath}/signin/{provider}' - use {provider} placeholder
+    callback?: string; // default: '{basePath}/callback/{provider}' - use {provider} placeholder
+  };
+}
+
+// Helper function to match a route pattern against a pathname
+function matchRoute(
+  pattern: string,
+  pathname: string
+): { matched: boolean; provider?: string } {
+  // Replace {provider} placeholder with a capture group
+  const regex = new RegExp(
+    "^" + pattern.replace(/\{provider\}/g, "([^/]+)") + "$"
+  );
+  const match = pathname.match(regex);
+  if (!match) return { matched: false };
+  return { matched: true, provider: match[1] };
+}
+
+// Helper function to build a route from pattern
+function buildRoute(pattern: string, provider?: string): string {
+  return provider ? pattern.replace(/\{provider\}/g, provider) : pattern;
 }
 
 export function createNextAuthHandler(
@@ -39,61 +64,123 @@ export function createNextAuthHandler(
   const successUrl = options.successRedirect || "/dashboard";
   const errorUrl = options.errorRedirect || "/login";
 
+  // Resolve route patterns with defaults
+  const routes = {
+    session: options.routes?.session || `${base}/session`,
+    signOut: options.routes?.signOut || `${base}/signout`,
+    signIn: options.routes?.signIn || `${base}/signin/{provider}`,
+    callback: options.routes?.callback || `${base}/callback/{provider}`,
+  };
+
   return async function handler(request: Request): Promise<Response> {
     const pathname = getPathname(request);
     const method = request.method.toUpperCase();
 
-    // Normalize action/provider from path: /{base}/{action}/{provider?}
-    const rel = pathname.startsWith(base)
-      ? pathname.slice(base.length)
-      : pathname;
-    const parts = rel.split("/").filter(Boolean);
-    const action = parts[0] || "";
-    const provider = parts[1] || "";
-
     try {
       // Session
-      if (action === "session" && method === "GET") {
+      if (pathname === routes.session && method === "GET") {
         const session = await getSession(request, config.secret);
         return Response.json({ session }, { status: 200 });
       }
 
       // Sign out
-      if (action === "signout" && method === "POST") {
+      if (pathname === routes.signOut && method === "POST") {
         await signOut(request, config);
         const res = Response.json({ success: true });
         res.headers.set("Set-Cookie", clearSessionCookie());
         return res;
       }
 
-      // OAuth sign-in start (exclude special providers handled below)
-      if (
-        action === "signin" &&
-        provider &&
-        method === "GET" &&
-        provider !== "twofa" &&
-        provider !== "email"
-      ) {
-        const result = await authenticate(config, request);
-        if (result.redirectUrl) {
-          const headers = new Headers();
-          headers.set("Location", result.redirectUrl);
-          // Set PKCE verifier cookie if provided
-          if (result.cookies && result.cookies.length > 0) {
-            result.cookies.forEach((cookie) => {
-              headers.append("Set-Cookie", cookie);
-            });
+      // Check for sign-in route match
+      const signInMatch = matchRoute(routes.signIn, pathname);
+      if (signInMatch.matched && method === "GET") {
+        const provider = signInMatch.provider;
+
+        // OAuth sign-in start (exclude special providers handled below)
+        if (provider && provider !== "twofa" && provider !== "email") {
+          const result = await authenticate(config, request);
+          if (result.redirectUrl) {
+            const headers = new Headers();
+            headers.set("Location", result.redirectUrl);
+            // Set PKCE verifier cookie if provided
+            if (result.cookies && result.cookies.length > 0) {
+              result.cookies.forEach((cookie) => {
+                headers.append("Set-Cookie", cookie);
+              });
+            }
+            return new Response(null, { status: 307, headers });
           }
-          return new Response(null, { status: 307, headers });
+          return Response.json(
+            { error: result.error || "Failed to start sign in" },
+            { status: 400 }
+          );
         }
-        return Response.json(
-          { error: result.error || "Failed to start sign in" },
-          { status: 400 }
-        );
+
+        // Two-Factor sign-in (send code or verify code)
+        if (provider === "twofa") {
+          const url = new URL(request.url);
+          const hasCode = url.searchParams.has("code");
+          const result = await authenticate(config, request);
+
+          // If redirectUrl is returned, it contains the identifier for code verification
+          // This happens after sending the code
+          if (result.redirectUrl && !hasCode) {
+            // Extract identifier from redirect URL and return as JSON
+            const redirectUrl = new URL(result.redirectUrl);
+            const identifier = redirectUrl.searchParams.get("identifier");
+            return Response.json(
+              { success: true, identifier },
+              { status: 200 }
+            );
+          }
+
+          // If session is returned, code was verified successfully
+          if (result.session) {
+            const location = new URL(successUrl, new URL(request.url).origin);
+            const headers = new Headers();
+            headers.set("Location", location.toString());
+            headers.append("Set-Cookie", createSessionCookie(result.session));
+            return new Response(null, { status: 307, headers });
+          }
+
+          return Response.json(
+            { error: result.error || "Failed to process 2FA request" },
+            { status: 400 }
+          );
+        }
       }
 
-      // OAuth/email callback
-      if (action === "callback" && provider && method === "GET") {
+      // Email sign-in initiate (send magic link) - POST method
+      if (
+        signInMatch.matched &&
+        signInMatch.provider === "email" &&
+        method === "POST"
+      ) {
+        const body = await request.json().catch(() => ({}));
+        const email = body?.email as string | undefined;
+        const captchaToken = body?.captchaToken as string | undefined;
+        if (!email)
+          return Response.json({ error: "Email is required" }, { status: 400 });
+
+        // Build callback URL with email and captchaToken params for magic link
+        const origin = new URL(request.url).origin;
+        const callbackUrl = buildRoute(routes.callback, "email");
+        const cb = new URL(callbackUrl, origin);
+        cb.searchParams.set("email", email);
+        if (captchaToken) {
+          cb.searchParams.set("captchaToken", captchaToken);
+        }
+        const mock = new Request(cb.toString());
+
+        const result = await authenticate(config, mock);
+        if (result.error)
+          return Response.json({ error: result.error }, { status: 400 });
+        return Response.json({ success: true });
+      }
+
+      // Check for callback route match
+      const callbackMatch = matchRoute(routes.callback, pathname);
+      if (callbackMatch.matched && callbackMatch.provider && method === "GET") {
         const result = await authenticate(config, request);
         if (result.error || !result.session) {
           const url = new URL(errorUrl, new URL(request.url).origin);
@@ -111,59 +198,6 @@ export function createNextAuthHandler(
           });
         }
         return new Response(null, { status: 307, headers });
-      }
-
-      // Email sign-in initiate (send magic link)
-      if (action === "signin" && provider === "email" && method === "POST") {
-        const body = await request.json().catch(() => ({}));
-        const email = body?.email as string | undefined;
-        const captchaToken = body?.captchaToken as string | undefined;
-        if (!email)
-          return Response.json({ error: "Email is required" }, { status: 400 });
-
-        // Build callback URL with email and captchaToken params for magic link
-        const origin = new URL(request.url).origin;
-        const cb = new URL(`${base}/callback/email`, origin);
-        cb.searchParams.set("email", email);
-        if (captchaToken) {
-          cb.searchParams.set("captchaToken", captchaToken);
-        }
-        const mock = new Request(cb.toString());
-
-        const result = await authenticate(config, mock);
-        if (result.error)
-          return Response.json({ error: result.error }, { status: 400 });
-        return Response.json({ success: true });
-      }
-
-      // Two-Factor sign-in (send code or verify code)
-      if (action === "signin" && provider === "twofa" && method === "GET") {
-        const url = new URL(request.url);
-        const hasCode = url.searchParams.has("code");
-        const result = await authenticate(config, request);
-
-        // If redirectUrl is returned, it contains the identifier for code verification
-        // This happens after sending the code
-        if (result.redirectUrl && !hasCode) {
-          // Extract identifier from redirect URL and return as JSON
-          const redirectUrl = new URL(result.redirectUrl);
-          const identifier = redirectUrl.searchParams.get("identifier");
-          return Response.json({ success: true, identifier }, { status: 200 });
-        }
-
-        // If session is returned, code was verified successfully
-        if (result.session) {
-          const location = new URL(successUrl, new URL(request.url).origin);
-          const headers = new Headers();
-          headers.set("Location", location.toString());
-          headers.append("Set-Cookie", createSessionCookie(result.session));
-          return new Response(null, { status: 307, headers });
-        }
-
-        return Response.json(
-          { error: result.error || "Failed to process 2FA request" },
-          { status: 400 }
-        );
       }
 
       return Response.json({ error: "Not Found" }, { status: 404 });

--- a/typings/next/handler.d.ts
+++ b/typings/next/handler.d.ts
@@ -3,5 +3,11 @@ export interface NextAuthHandlerOptions {
     basePath?: string;
     successRedirect?: string;
     errorRedirect?: string;
+    routes?: {
+        session?: string;
+        signOut?: string;
+        signIn?: string;
+        callback?: string;
+    };
 }
 export declare function createNextAuthHandler(config: AuthConfig, options?: NextAuthHandlerOptions): (request: Request) => Promise<Response>;


### PR DESCRIPTION
- Updated `CLAUDE.md` to include details on custom authentication route paths, allowing users to configure their own endpoints.
- Added a new guide on custom route paths in `content/docs/03-guides/06-custom-route-paths.mdx`, providing comprehensive examples and best practices for implementation.
- Modified example proxy configurations to demonstrate the use of custom routes.
- Created a new README file in the `examples/nextjs-captcha-example` directory to illustrate custom route paths with practical examples.

These changes improve the documentation and examples, making it easier for developers to implement and customize authentication routes in their applications.